### PR TITLE
[Yeo Si Zhao] Implement Junit tests for Category and Item

### DIFF
--- a/src/main/java/seedu/duke/model/Item.java
+++ b/src/main/java/seedu/duke/model/Item.java
@@ -5,7 +5,7 @@ public class Item {
     private int quantity;
     private String binLocation;
 
-    protected Item(String name, int quantity, String binLocation) {
+    public Item(String name, int quantity, String binLocation) {
         this.name = name;
         this.quantity = quantity;
         this.binLocation = binLocation;

--- a/src/test/java/seedu/duke/CategoryTest.java
+++ b/src/test/java/seedu/duke/CategoryTest.java
@@ -1,0 +1,114 @@
+package seedu.duke;
+
+import org.junit.jupiter.api.Test;
+import seedu.duke.model.Category;
+import seedu.duke.model.Item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CategoryTest {
+
+    @Test
+    public void constructor_validName_nameSetAndItemsEmpty() {
+        Category category = new Category("Fruits");
+
+        assertEquals("Fruits", category.getName());
+        assertEquals(0, category.getItemCount());
+        assertTrue(category.isEmpty());
+    }
+
+    @Test
+    public void setName_validName_nameUpdated() {
+        Category category = new Category("Fruits");
+        category.setName("Vegetables");
+
+        assertEquals("Vegetables", category.getName());
+    }
+
+    @Test
+    public void addItem_validItem_itemAdded() {
+        Category category = new Category("Fruits");
+        Item item = new Item("Apple", 5, "A1");
+
+        category.addItem(item);
+
+        assertEquals(1, category.getItemCount());
+        assertFalse(category.isEmpty());
+        assertEquals(item, category.getItem(0));
+    }
+
+    @Test
+    public void getItem_validIndex_returnsCorrectItem() {
+        Category category = new Category("Fruits");
+        Item item = new Item("Apple", 5, "A1");
+        category.addItem(item);
+
+        assertEquals(item, category.getItem(0));
+    }
+
+    @Test
+    public void removeItem_validIndex_itemRemoved() {
+        Category category = new Category("Fruits");
+        Item item1 = new Item("Apple", 5, "A1");
+        Item item2 = new Item("Banana", 3, "A2");
+
+        category.addItem(item1);
+        category.addItem(item2);
+        category.removeItem(0);
+
+        assertEquals(1, category.getItemCount());
+        assertEquals(item2, category.getItem(0));
+    }
+
+    @Test
+    public void findItemByName_existingItem_returnsItem() {
+        Category category = new Category("Fruits");
+        Item item = new Item("Apple", 5, "A1");
+        category.addItem(item);
+
+        assertEquals(item, category.findItemByName("Apple"));
+    }
+
+    @Test
+    public void findItemByName_caseInsensitive_returnsItem() {
+        Category category = new Category("Fruits");
+        Item item = new Item("Apple", 5, "A1");
+        category.addItem(item);
+
+        assertEquals(item, category.findItemByName("apple"));
+    }
+
+    @Test
+    public void findItemByName_nonExistingItem_returnsNull() {
+        Category category = new Category("Fruits");
+        category.addItem(new Item("Apple", 5, "A1"));
+
+        assertNull(category.findItemByName("Banana"));
+    }
+
+    @Test
+    public void toString_emptyCategory_correctFormat() {
+        Category category = new Category("Fruits");
+
+        assertEquals("Category: Fruits\n", category.toString());
+    }
+
+    @Test
+    public void toString_withItems_correctFormat() {
+        Category category = new Category("Fruits");
+        Item item1 = new Item("Apple", 5, "A1");
+        Item item2 = new Item("Banana", 3, "A2");
+
+        category.addItem(item1);
+        category.addItem(item2);
+
+        String expected = "Category: Fruits\n"
+                + "  1. Name: Apple, Quantity: 5, Bin: A1\n"
+                + "  2. Name: Banana, Quantity: 3, Bin: A2\n";
+
+        assertEquals(expected, category.toString());
+    }
+}

--- a/src/test/java/seedu/duke/ItemTest.java
+++ b/src/test/java/seedu/duke/ItemTest.java
@@ -1,0 +1,52 @@
+package seedu.duke;
+
+import org.junit.jupiter.api.Test;
+import seedu.duke.model.Item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ItemTest {
+
+    @Test
+    public void constructor_validInputs_fieldsSetCorrectly() {
+        Item item = new Item("Apple", 5, "A1");
+
+        assertEquals("Apple", item.getName());
+        assertEquals(5, item.getQuantity());
+        assertEquals("A1", item.getBinLocation());
+    }
+
+    @Test
+    public void setName_validName_nameUpdated() {
+        Item item = new Item("Apple", 5, "A1");
+
+        item.setName("Banana");
+
+        assertEquals("Banana", item.getName());
+    }
+
+    @Test
+    public void setQuantity_validQuantity_quantityUpdated() {
+        Item item = new Item("Apple", 5, "A1");
+
+        item.setQuantity(10);
+
+        assertEquals(10, item.getQuantity());
+    }
+
+    @Test
+    public void setBinLocation_validBinLocation_binLocationUpdated() {
+        Item item = new Item("Apple", 5, "A1");
+
+        item.setBinLocation("B2");
+
+        assertEquals("B2", item.getBinLocation());
+    }
+
+    @Test
+    public void toString_validItem_correctFormat() {
+        Item item = new Item("Apple", 5, "A1");
+
+        assertEquals("Name: Apple, Quantity: 5, Bin: A1", item.toString());
+    }
+}


### PR DESCRIPTION
Summary:
This PR adds JUnit tests for the `Category` and `Item` model classes.

Changes made:
- Added `CategoryTest` to verify category creation, renaming, adding/removing items, item lookup, item count, empty-state checks, and string formatting
- Added `ItemTest` to verify item creation, getters/setters, and string formatting

Why:
These tests improve confidence in the correctness of the core inventory model classes and provide regression coverage for future changes.

Testing:
- Ran all added JUnit tests locally
- All tests passed